### PR TITLE
Add card flipping animation 

### DIFF
--- a/src/Card.css
+++ b/src/Card.css
@@ -18,9 +18,6 @@
     height: 100%;
     position: relative;
     text-align: center;
-    /* Temp disabling card flip animation */
-    /* transition: transform .5s; */
-    transform-style: preserve-3d;
     width: 100%;
 }
 
@@ -31,11 +28,8 @@
 /* Card flipping animation when turned face up */
 .card.faceup .card-inner {
     transform: rotateY(180deg);
-}
-
-.card.faceup .back img {
-    opacity: 0;
-    transition: opacity 2s;
+    transform-style: preserve-3d;
+    transition: transform .5s;
 }
 
 .back,

--- a/src/Card.css
+++ b/src/Card.css
@@ -21,7 +21,7 @@
     width: 100%;
 }
 
-.card.faceup {
+.card[draggable="true"] {
     cursor: grab;
 }
 

--- a/src/Card.js
+++ b/src/Card.js
@@ -45,7 +45,7 @@ export default function Card(props) {
   return (
     <div
       className={className}
-      draggable={!!(props.face === "up")}
+      draggable={props.draggable}
       data-carddata={JSON.stringify(props)}
       data-testid="card"
       onDragStart={onDragStart}

--- a/src/Solitaire.css
+++ b/src/Solitaire.css
@@ -31,6 +31,19 @@
   grid-column: 2/3;
 }
 
+#waste > div {
+  transition: transform .5s;
+}
+
+#waste.offset-two > div:nth-last-child(1) {
+  transform: translatex(8vw);
+}
+
+#waste.offset-one > div:nth-last-child(1), 
+#waste.offset-two > div:nth-last-child(2) {
+  transform: translatex(4vw);
+}
+
 #tableau {
   grid-column: 1/8;
   grid-row: 2;

--- a/src/Solitaire.js
+++ b/src/Solitaire.js
@@ -93,7 +93,8 @@ export default function Solitaire(props) {
 
     // If the draw pile is empty, and the waste pile has cards, move the waste pile back to the draw pile
     if (!newPlayfieldState.draw.length && newPlayfieldState.waste.length) {
-      newPlayfieldState.draw = newPlayfieldState.waste.reverse();
+      // Also set the cards face down
+      newPlayfieldState.draw = newPlayfieldState.waste.reverse().map(cardData => { cardData.face = "down"; return cardData; });
       newPlayfieldState.waste = [];
     } else if (newPlayfieldState.draw.length) {
       // Add the last card from the draw pile to the waste pile
@@ -152,10 +153,10 @@ export default function Solitaire(props) {
           {playfieldState.draw.map((cardData, cardIndex) => {
             return (
               <Card
-                key={`${cardData.rank}_${cardData.suit}_${cardData.face}_draw_${cardIndex}`}
+                key={`${cardData.rank}_${cardData.suit}`}
                 rank={cardData.rank}
                 suit={cardData.suit}
-                face="down"
+                face={cardData.face}
                 pileType="draw"
                 cardIndex={cardIndex}
               />
@@ -176,10 +177,10 @@ export default function Solitaire(props) {
         {playfieldState.waste.map((cardData, cardIndex) => {
           return (
             <Card
-              key={`${cardData.rank}_${cardData.suit}_${cardData.face}_waste_${cardIndex}`}
+              key={`${cardData.rank}_${cardData.suit}`}
               rank={cardData.rank}
               suit={cardData.suit}
-              face="up"
+              face={cardData.face}
               pileType="waste"
               cardIndex={cardIndex}
             />
@@ -211,10 +212,10 @@ export default function Solitaire(props) {
                 cardDataList.map((cardData, cardIndex) => {
                   return (
                     <Card
-                      key={`${cardData.rank}_${cardData.suit}_${cardData.face}_foundation_${pileIndex}_${cardIndex}`}
+                      key={`${cardData.rank}_${cardData.suit}`}
                       rank={cardData.rank}
                       suit={cardData.suit}
-                      face="up"
+                      face={cardData.face}
                       pileType="foundation"
                       pileindex={pileIndex}
                       cardIndex={cardIndex}
@@ -247,13 +248,9 @@ export default function Solitaire(props) {
             >
               {
                 cardDataList.map((cardData, cardIndex) => {
-                  // Last card should always be up
-                  const lastCard = cardIndex + 1 === cardDataList.length;
-                  cardData.face = lastCard ? "up" : cardData.face;
-
                   return (
                     <Card
-                      key={`${cardData.rank}_${cardData.suit}_${cardData.face}_tableau_${pileIndex}_${cardIndex}`}
+                      key={`${cardData.rank}_${cardData.suit}`}
                       rank={cardData.rank}
                       suit={cardData.suit}
                       face={cardData.face}
@@ -574,7 +571,7 @@ export default function Solitaire(props) {
   function moveCard(sourceCardData, targetPileType, targetPileIndex) {
 
     const newPlayfieldState = structuredClone(playfieldState);
- 
+
     // Remove the card (and any subsequent cards) from the source pile
     const { pileType: sourcePileType, pileindex: sourcePileIndex, cardIndex: sourceCardIndex } = sourceCardData;
     let cardsToMove;
@@ -591,6 +588,9 @@ export default function Solitaire(props) {
       default:
         return;
     }
+
+    // Make sure any cards being moved are set to be face up
+    cardsToMove.forEach(cardData => cardData.face = "up");
 
     // Move cards to target pile
     switch (targetPileType) {
@@ -694,21 +694,60 @@ export default function Solitaire(props) {
   }
 
   /**
-   * Checks the playfield to see if the game has been won
+   * Checks the game state to see if any updates are needed
    */
   function checkGameState() {
-    if (playfieldState.foundation.length) {
 
-      let numFoundationCards = 0;
-      playfieldState.foundation.forEach(pileCards => { numFoundationCards += pileCards.length; });
+    // Checks the playfield to see if the game has been won
+    let numFoundationCards = 0;
+    playfieldState.foundation.forEach(pileCards => { numFoundationCards += pileCards.length; });
 
-      if (numFoundationCards === 52) {
-        // Stop the timer
-        stopTimer();
+    if (numFoundationCards === 52) {
+      // Stop the timer
+      stopTimer();
 
-        // Display the "winner" modal
-        setModalTypeDisplayed(modalTypes.GameWin);
+      // Display the "winner" modal
+      setModalTypeDisplayed(modalTypes.GameWin);
+
+      return;
+    }
+
+    // Check to see which cards need to be flipped
+    // This step is needed so that the card flipping animation has something to transition to (face down => face up)
+    let updatePlayfield = false;
+    let newPlayfieldState = structuredClone(playfieldState);
+
+    // Flip the last card on each tableau pile
+    newPlayfieldState.tableau = playfieldState.tableau.map((cardDataList) => {
+      return cardDataList.map((cardData, cardIndex) => {
+        // Last card should always be up
+        const lastCard = cardIndex + 1 === cardDataList.length;
+
+        if (lastCard && cardData.face !== "up") {
+          updatePlayfield = true;
+          cardData.face = "up";
+        }
+
+        return cardData;
+      });
+    });
+
+    // Flip the last card on the waste pile
+    newPlayfieldState.waste = playfieldState.waste.map((cardData, cardIndex) => {
+      // Last card should always be up
+      const lastCard = cardIndex + 1 === playfieldState.waste.length;
+
+      if (lastCard && cardData.face !== "up") {
+        updatePlayfield = true;
+        cardData.face = "up";
       }
+
+      return cardData;
+    });
+
+    // Update the playfield if any cards need to be updated
+    if (updatePlayfield) {
+      setPlayfieldState(newPlayfieldState);
     }
   }
 

--- a/src/Solitaire.js
+++ b/src/Solitaire.js
@@ -106,25 +106,6 @@ export default function Solitaire(props) {
   }
 
   /**
-   * Handles clicks on the waste card pile to automatically move card the top card to new piles
-   * @param {Event} e The click event
-   */
-  function wastePileClickHandler(e) {
-
-    if (!e || !e.target) {
-      return;
-    }
-
-    // Get the card data from the last card on the waste pile
-    const tappedCardElement = e.target.closest(".card");
-    const tapppedCardData = tappedCardElement && JSON.parse(tappedCardElement.getAttribute("data-carddata"));
-
-    if (tapppedCardData && tappedCardElement.getAttribute("draggable") === "true") {
-      checkAndMoveCard(tapppedCardData);
-    }
-  }
-
-  /**
    * Handles clicks on card piles to automatically move cards to new piles
    * @param {Event} e The click event
    */
@@ -138,33 +119,25 @@ export default function Solitaire(props) {
     const tappedCardElement = e.target.closest(".card");
     const tapppedCardData = tappedCardElement && JSON.parse(tappedCardElement.getAttribute("data-carddata"));
 
-    if (tapppedCardData && tapppedCardData.face === "up") {
-      checkAndMoveCard(tapppedCardData);
-    }
-  }
+    if (tapppedCardData && tapppedCardData.face === "up" && tappedCardElement.getAttribute("draggable") === "true") {
+      // Check to see if the card can be moved to one of the foundation piles
+      let result = playfieldState.foundation.findIndex((foundationCardPileData) => {
+        return isValidMove(tapppedCardData, foundationCardPileData.length ? foundationCardPileData.slice(-1)[0] : null, "foundation");
+      })
 
-  /**
-   * Checks for a valid move for a card and moves it if it finds one
-   * @param {*} cardData Card data to check
-   */
-  function checkAndMoveCard(cardData) {
-    // Check to see if the card can be moved to one of the foundation piles
-    let result = playfieldState.foundation.findIndex((foundationCardPileData) => {
-      return isValidMove(cardData, foundationCardPileData.length ? foundationCardPileData.slice(-1)[0] : null, "foundation");
-    })
+      if (result !== -1) {
+        moveCard(tapppedCardData, "foundation", result);
+        return;
+      }
 
-    if (result !== -1) {
-      moveCard(cardData, "foundation", result);
-      return;
-    }
+      // Check to see if this card can be moved to one of the tableau piles
+      result = playfieldState.tableau.findIndex((tableauCardPileData) => {
+        return isValidMove(tapppedCardData, tableauCardPileData.length ? tableauCardPileData.slice(-1)[0] : null, "tableau");
+      })
 
-    // Check to see if this card can be moved to one of the tableau piles
-    result = playfieldState.tableau.findIndex((tableauCardPileData) => {
-      return isValidMove(cardData, tableauCardPileData.length ? tableauCardPileData.slice(-1)[0] : null, "tableau");
-    })
-
-    if (result !== -1) {
-      moveCard(cardData, "tableau", result);
+      if (result !== -1) {
+        moveCard(tapppedCardData, "tableau", result);
+      }
     }
   }
 
@@ -209,7 +182,7 @@ export default function Solitaire(props) {
     }
 
     return (
-      <div id="waste" onClick={wastePileClickHandler} className={className}>
+      <div id="waste" onClick={pileClickHandler} className={className}>
         {playfieldState.waste.map((cardData, cardIndex) => {
           const lastCard = cardIndex + 1 === playfieldState.waste.length;
           return (

--- a/src/Solitaire.js
+++ b/src/Solitaire.js
@@ -106,6 +106,25 @@ export default function Solitaire(props) {
   }
 
   /**
+   * Handles clicks on the waste card pile to automatically move card the top card to new piles
+   * @param {Event} e The click event
+   */
+  function wastePileClickHandler(e) {
+
+    if (!e || !e.target) {
+      return;
+    }
+
+    // Get the card data from the last card on the waste pile
+    const tappedCardElement = e.target.closest(".card");
+    const tapppedCardData = tappedCardElement && JSON.parse(tappedCardElement.getAttribute("data-carddata"));
+
+    if (tapppedCardData && tappedCardElement.getAttribute("draggable") === "true") {
+      checkAndMoveCard(tapppedCardData);
+    }
+  }
+
+  /**
    * Handles clicks on card piles to automatically move cards to new piles
    * @param {Event} e The click event
    */
@@ -119,27 +138,33 @@ export default function Solitaire(props) {
     const tappedCardElement = e.target.closest(".card");
     const tapppedCardData = tappedCardElement && JSON.parse(tappedCardElement.getAttribute("data-carddata"));
 
-    if (!tapppedCardData || (tapppedCardData && tapppedCardData.face === "down")) {
-      return;
+    if (tapppedCardData && tapppedCardData.face === "up") {
+      checkAndMoveCard(tapppedCardData);
     }
+  }
 
+  /**
+   * Checks for a valid move for a card and moves it if it finds one
+   * @param {*} cardData Card data to check
+   */
+  function checkAndMoveCard(cardData) {
     // Check to see if the card can be moved to one of the foundation piles
     let result = playfieldState.foundation.findIndex((foundationCardPileData) => {
-      return isValidMove(tapppedCardData, foundationCardPileData.length ? foundationCardPileData.slice(-1)[0] : null, "foundation");
+      return isValidMove(cardData, foundationCardPileData.length ? foundationCardPileData.slice(-1)[0] : null, "foundation");
     })
 
     if (result !== -1) {
-      moveCard(tapppedCardData, "foundation", result);
+      moveCard(cardData, "foundation", result);
       return;
     }
 
     // Check to see if this card can be moved to one of the tableau piles
     result = playfieldState.tableau.findIndex((tableauCardPileData) => {
-      return isValidMove(tapppedCardData, tableauCardPileData.length ? tableauCardPileData.slice(-1)[0] : null, "tableau");
+      return isValidMove(cardData, tableauCardPileData.length ? tableauCardPileData.slice(-1)[0] : null, "tableau");
     })
 
     if (result !== -1) {
-      moveCard(tapppedCardData, "tableau", result);
+      moveCard(cardData, "tableau", result);
     }
   }
 
@@ -154,6 +179,7 @@ export default function Solitaire(props) {
             return (
               <Card
                 key={`${cardData.rank}_${cardData.suit}`}
+                draggable={false}
                 rank={cardData.rank}
                 suit={cardData.suit}
                 face={cardData.face}
@@ -172,12 +198,24 @@ export default function Solitaire(props) {
    * Renders the waste pile of cards
    */
   function renderWastePile() {
+
+    let className = "";
+    const wasteCardCount = playfieldState.waste.length;
+
+    if (wasteCardCount >= 3) {
+      className = "offset-two";
+    } else if (wasteCardCount === 2) {
+      className = "offset-one";
+    }
+
     return (
-      <div id="waste" onClick={pileClickHandler}>
+      <div id="waste" onClick={wastePileClickHandler} className={className}>
         {playfieldState.waste.map((cardData, cardIndex) => {
+          const lastCard = cardIndex + 1 === playfieldState.waste.length;
           return (
             <Card
               key={`${cardData.rank}_${cardData.suit}`}
+              draggable={lastCard}
               rank={cardData.rank}
               suit={cardData.suit}
               face={cardData.face}
@@ -213,6 +251,7 @@ export default function Solitaire(props) {
                   return (
                     <Card
                       key={`${cardData.rank}_${cardData.suit}`}
+                      draggable={!!(cardData.face === "up")}
                       rank={cardData.rank}
                       suit={cardData.suit}
                       face={cardData.face}
@@ -251,6 +290,7 @@ export default function Solitaire(props) {
                   return (
                     <Card
                       key={`${cardData.rank}_${cardData.suit}`}
+                      draggable={!!(cardData.face === "up")}
                       rank={cardData.rank}
                       suit={cardData.suit}
                       face={cardData.face}


### PR DESCRIPTION
Changes made:
- Enabled card flipping CSS animations
- Added a secondary state change to flip cards face up after first rendering them face down. This is needed so the CSS animations have something to transition.
- Updated the waste pile display to offset the top two cards in the pile
- Updated the waste pile click handler so only the top card can be moved