### PR TITLE
Fixing CSS bug in Firefox

### DIFF
--- a/src/Card.css
+++ b/src/Card.css
@@ -32,6 +32,10 @@
     transition: transform .5s;
 }
 
+.card.faceup .back {
+    display: none;
+}
+
 .back,
 .face {
     /* Safari */


### PR DESCRIPTION
Changes made:
- Updated CSS to hide the back when the card is face up. This worked fine in Chromium browsers, but not Firefox. 